### PR TITLE
Added AggregateModel

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/AggregateModel.php
+++ b/src/AggregateModel.php
@@ -2,17 +2,20 @@
 
 namespace Watson\Aggregate;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * Loads the Aggregate options in the new Query method.
  * This loads just like withCount
  */
-class AggregateModel extends Model
+abstract class AggregateModel extends Model
 {
 
     /**
      * The relationship sums that should be eager loaded on every query.
+     * Each entry is an array shaped like so:
+     *  [relationship, column]
      *
      * @var array
      */
@@ -20,6 +23,8 @@ class AggregateModel extends Model
 
     /**
      * The relationship averages that should be eager loaded on every query.
+     * Each entry is an array shaped like so:
+     *  [relationship, column]
      *
      * @var array
      */
@@ -27,6 +32,8 @@ class AggregateModel extends Model
 
     /**
      * The relationship maximums that should be eager loaded on every query.
+     * Each entry is an array shaped like so:
+     *  [relationship, column]
      *
      * @var array
      */
@@ -34,6 +41,8 @@ class AggregateModel extends Model
 
     /**
      * The relationship minimums that should be eager loaded on every query.
+     * Each entry is an array shaped like so:
+     *  [relationship, column]
      *
      * @var array
      */
@@ -49,11 +58,23 @@ class AggregateModel extends Model
         $query = parent::newQueryWithoutScopes();
 
         // Check that the Aggregate Service Provider is loaded.
-        if(method_exists($this, "withAggregate")) {
-            $query->withSum($this->withSum)
-                ->withAvg($this->withAvg)
-                ->withMax($this->withMax)
-                ->withMin($this->withMin);
+        if(Builder::hasGlobalMacro("withAggregate")) {
+            foreach($this->withSum as $entry) {
+                [$relationship, $column] = is_array($entry) ? $entry : [$entry];
+                $query->withSum($relationship, $column);
+            }
+            foreach($this->withAvg as $entry) {
+                [$relationship, $column] = is_array($entry) ? $entry : [$entry];
+                $query->withAvg($relationship, $column);
+            }
+            foreach($this->withMax as $entry) {
+                [$relationship, $column] = is_array($entry) ? $entry : [$entry];
+                $query->withMax($relationship, $column);
+            }
+            foreach($this->withMin as $entry) {
+                [$relationship, $column] = is_array($entry) ? $entry : [$entry];
+                $query->withMin($relationship, $column);
+            }
         }
 
         return $query;

--- a/src/AggregateModel.php
+++ b/src/AggregateModel.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Watson\Aggregate;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Loads the Aggregate options in the new Query method.
+ * This loads just like withCount
+ */
+class AggregateModel extends Model
+{
+
+    /**
+     * The relationship sums that should be eager loaded on every query.
+     *
+     * @var array
+     */
+    protected $withSum = [];
+
+    /**
+     * The relationship averages that should be eager loaded on every query.
+     *
+     * @var array
+     */
+    protected $withAvg = [];
+
+    /**
+     * The relationship maximums that should be eager loaded on every query.
+     *
+     * @var array
+     */
+    protected $withMax = [];
+
+    /**
+     * The relationship minimums that should be eager loaded on every query.
+     *
+     * @var array
+     */
+    protected $withMin = [];
+
+    /**
+     * Get a new query builder that doesn't have any global scopes.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function newQueryWithoutScopes()
+    {
+        $query = parent::newQueryWithoutScopes();
+
+        // Check that the Aggregate Service Provider is loaded.
+        if(method_exists($this, "withAggregate")) {
+            $query->withSum($this->withSum)
+                ->withAvg($this->withAvg)
+                ->withMax($this->withMax)
+                ->withMin($this->withMin);
+        }
+
+        return $query;
+    }
+
+}
+
+?>

--- a/tests/AggregateTest.php
+++ b/tests/AggregateTest.php
@@ -129,12 +129,16 @@ class AggregateTest extends TestCase
         $actual = OrderWithAggregate::first();
 
         $expected = DB::select(
-            DB::raw('select (select sum(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "order_price", (select sum(quantity) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "order_products_count", (select count(*) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_count" from "orders"')
+            DB::raw('select (select sum(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "order_price", (select count(*) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_count", (select sum(quantity) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "order_products_count", (select min(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_min_price", (select max(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_max_price", (select avg(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_avg_price" from "orders"')
         )[0];
 
+        // TODO: Test more of the returned results. (Just look at the previous tests to get the values expected)
         $this->assertEquals($expected->order_price, $actual->order_price);
         $this->assertEquals($expected->products_count, $actual->products_count);
         $this->assertEquals($expected->order_products_count, $actual->order_products_count);
+        $this->assertEquals($expected->products_min_price, $actual->products_min_price);
+        $this->assertEquals($expected->products_max_price, $actual->products_max_price);
+        $this->assertEquals($expected->products_avg_price, $actual->products_avg_price);
     }
 }
 
@@ -153,15 +157,15 @@ class OrderWithAggregate extends AggregateModel
     ];
 
     protected $withMin = [
-        ["products", "price"]
+        ["products as products_min_price", "price"]
     ];
 
     protected $withMax = [
-        ["products", "price"]
+        ["products as products_max_price", "price"]
     ];
 
     protected $withAvg = [
-        ["products", "price"]
+        ["products as products_avg_price", "price"]
     ];
 
     public function products()

--- a/tests/AggregateTest.php
+++ b/tests/AggregateTest.php
@@ -25,7 +25,8 @@ class AggregateTest extends TestCase
 
     public function testWithCount()
     {
-        $actual = Order::withAggregate('products', 'count', '*')->first();
+        $actual = Order::withAggregate('products', 'count', '*')
+            ->first();
 
         $expected = DB::select(
             DB::raw('select (select count(*) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_count" from "orders"')
@@ -36,7 +37,8 @@ class AggregateTest extends TestCase
 
     public function testWithSum()
     {
-        $actual = Order::withSum('products', 'quantity')->first();
+        $actual = Order::withSum('products', 'quantity')
+            ->first();
 
         $expected = DB::select(
             DB::raw('select (select sum(quantity) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_sum" from "orders"')
@@ -47,7 +49,8 @@ class AggregateTest extends TestCase
 
     public function testWithAvg()
     {
-        $actual = Order::withAvg('products', 'price')->first();
+        $actual = Order::withAvg('products', 'price')
+            ->first();
 
         $expected = DB::select(
             DB::raw('select (select avg(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_avg" from "orders"')
@@ -58,7 +61,8 @@ class AggregateTest extends TestCase
 
     public function testWithMin()
     {
-        $actual = Order::withMin('products', 'price')->first();
+        $actual = Order::withMin('products', 'price')
+            ->first();
 
         $expected = DB::select(
             DB::raw('select (select min(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_min" from "orders"')
@@ -69,7 +73,8 @@ class AggregateTest extends TestCase
 
     public function testWithMax()
     {
-        $actual = Order::withMax('products', 'price')->first();
+        $actual = Order::withMax('products', 'price')
+            ->first();
 
         $expected = DB::select(
             DB::raw('select (select max(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_max" from "orders"')
@@ -80,7 +85,8 @@ class AggregateTest extends TestCase
 
     public function testWithMinAndAlias()
     {
-        $actual = Order::withMin('products as min_price', 'price')->first();
+        $actual = Order::withMin('products as min_price', 'price')
+            ->first();
 
         $expected = DB::select(
             DB::raw('select (select min(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "min_price" from "orders"')
@@ -104,7 +110,10 @@ class AggregateTest extends TestCase
 
     public function testWithSumPricesAndCountQuantityWithAliases()
     {
-        $actual = Order::withSum('products as order_price', 'price')->withSum('products as order_products_count', 'quantity')->withCount('products')->first();
+        $actual = Order::withSum('products as order_price', 'price')
+            ->withSum('products as order_products_count', 'quantity')
+            ->withCount('products')
+            ->first();
 
         $expected = DB::select(
             DB::raw('select (select sum(price) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "order_price", (select sum(quantity) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "order_products_count", (select count(*) from "product_orders" where "orders"."id" = "product_orders"."order_id") as "products_count" from "orders"')


### PR DESCRIPTION
This PR contains additive changes to allow for models to extended off of a new class called `AggregateModel` to allow for the default query to include the default aggregate options.

In a normal Laravel model, you have access to use `protected $withCount` options. This adds support for the following items to add a native feel to the use of the aggregate model.

```php
protected $withSum = [];
protected $withAvg = [];
protected $withMax = [];
protected $withMin = [];
```